### PR TITLE
Removing matplotlib backend dependancies

### DIFF
--- a/src/napari_workflow_inspector/_dock_widget.py
+++ b/src/napari_workflow_inspector/_dock_widget.py
@@ -9,8 +9,8 @@ from napari_tools_menu import register_dock_widget
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5 import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
-import matplotlib
-matplotlib.use('Qt5Agg')
+# import matplotlib
+# matplotlib.use('Qt5Agg')
 
 import pickle
 import networkx as nx

--- a/src/napari_workflow_inspector/_dock_widget.py
+++ b/src/napari_workflow_inspector/_dock_widget.py
@@ -9,10 +9,7 @@ from napari_tools_menu import register_dock_widget
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5 import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
-# import matplotlib
-# matplotlib.use('Qt5Agg')
 
-import pickle
 import networkx as nx
 
 


### PR DESCRIPTION
This small change removes the manual setting of the backend as discussed [here](https://github.com/BiAPoL/napari-clusters-plotter/issues/76) as well as some unused library imports. For me the functionality still was mantained when making a workflow with the napari assistant. 